### PR TITLE
Add CI workflow and contributing guide

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    - name: Run tests
+      run: |
+        pytest -q

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,15 @@
+# Contributing to Trade_FinRL_Codex
+
+Thank you for considering contributing!
+
+## Issues
+
+1. Search existing issues to avoid duplicates.
+2. Open a new issue and provide as much detail as possible.
+
+## Pull Requests
+
+1. Fork the repository and create your branch from `main`.
+2. Ensure your branch builds and tests pass.
+3. Open a pull request describing your changes.
+4. Link any relevant issues in the pull request description.


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run tests
- add CONTRIBUTING file with instructions on opening issues and pull requests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d26908b088323b0d6b8a0caeb9705